### PR TITLE
Making Jetbrains IDEs happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Jetbrains IDE files
+.idea/
+
+# Python virtual environment
+venv/
+
+# Compiled python files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+
+
+# Main executable that doesn't want uploading yet
+main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py[voice]


### PR DESCRIPTION
IDEs like PyCharm like having a `requirements.txt` file.
It is sometimes useful to use a virtual environment and IDEs create their own files. These files don't need uploading to the repo so adding a `.gitignore` file is a good idea.